### PR TITLE
refactor IPreflightResourceReader to make it less clever

### DIFF
--- a/src/server/API/Controllers/ConceptController.cs
+++ b/src/server/API/Controllers/ConceptController.cs
@@ -199,14 +199,13 @@ namespace API.Controllers
         [HttpPost("{uid}/preflight")]
         public async Task<ActionResult> Preflight(
             string uid,
-            [FromServices] IPreflightConceptReader preflightReader)
+            [FromServices] PreflightResourceChecker preflight)
         {
             try
             {
                 var @ref = new ConceptRef(uid);
-                var preflight = await preflightReader.GetAsync(@ref);
-                log.LogInformation("Preflight check universal concept result. UId:{UId} Result:{@Result}", uid, preflight.PreflightCheck);
-                var check = new ConceptPreflightCheckDTO(preflight.PreflightCheck);
+                var result = await preflight.GetConceptsAsync(@ref);
+                var check = new ConceptPreflightCheckDTO(result.PreflightCheck);
                 return Ok(check);
             }
             catch (FormatException fe)

--- a/src/server/API/Controllers/QueryController.cs
+++ b/src/server/API/Controllers/QueryController.cs
@@ -196,22 +196,16 @@ namespace API.Controllers
             }
         }
 
-        //[HttpPut("{ident}/share")]
-        //public ActionResult Share(string ident, [FromBody] PatientCountQueryDTO query)
-        //{
-        //    return NotFound();
-        //}
-
         [Authorize(Policy = Access.Institutional)]
         [HttpPost("preflight")]
         public async Task<ActionResult<PreflightCheckDTO>> Preflight(
             [FromBody] ResourceRef resourceRef,
-            [FromServices] IPreflightResourceReader preflightReader)
+            [FromServices] PreflightResourceChecker preflight)
         {
             try
             {
                 var refs = new ResourceRefs(new ResourceRef[] { resourceRef });
-                var preflightResources = await preflightReader.GetAsync(refs);
+                var preflightResources = await preflight.GetResourcesAsync(refs);
                 return Ok(new PreflightCheckDTO(preflightResources));
             }
             catch (LeafDbException lde)

--- a/src/server/API/Options/StartupExtensions.Services.cs
+++ b/src/server/API/Options/StartupExtensions.Services.cs
@@ -116,6 +116,7 @@ namespace API.Options
             services.AddTransient<ConceptHintSearcher>();
             services.AddTransient<ConceptTreeSearcher>();
             services.AddTransient<PanelConverter>();
+            services.AddTransient<PreflightResourceChecker>();
 
             return services;
         }

--- a/src/server/Model/Compiler/PanelConverter.cs
+++ b/src/server/Model/Compiler/PanelConverter.cs
@@ -29,17 +29,17 @@ namespace Model.Compiler
     public class PanelConverter
     {
         readonly IUserContext user;
-        readonly IPreflightResourceReader preflightReader;
+        readonly PreflightResourceChecker preflightSearch;
         readonly ILogger<PanelConverter> log;
         readonly CompilerOptions compilerOptions;
 
         public PanelConverter(
-            IPreflightResourceReader preflightConceptReader,
+            PreflightResourceChecker preflightSearch,
             IUserContext userContext,
             IOptions<CompilerOptions> compilerOptions,
             ILogger<PanelConverter> logger)
         {
-            preflightReader = preflightConceptReader;
+            this.preflightSearch = preflightSearch;
             user = userContext;
             this.compilerOptions = compilerOptions.Value;
             log = logger;
@@ -118,7 +118,7 @@ namespace Model.Compiler
                                   .Select(i => i.Resource);
             var resources = new ResourceRefs(requested);
 
-            return await preflightReader.GetAsync(resources);
+            return await preflightSearch.GetResourcesAsync(resources);
         }
 
         IEnumerable<Panel> GetPanels(IEnumerable<IPanelDTO> panels, IEnumerable<Concept> concepts)

--- a/src/server/Model/Search/IPreflightResourceReader.cs
+++ b/src/server/Model/Search/IPreflightResourceReader.cs
@@ -6,17 +6,22 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Model.Compiler;
+using Model.Tagging;
+using System;
 
 namespace Model.Search
 {
     public interface IPreflightResourceReader : IPreflightConceptReader
     {
-        Task<PreflightResources> GetAsync(ResourceRefs refs);
+        Task<PreflightResources> GetResourcesByIdsAsync(ResourceRefs refs);
+        Task<PreflightResources> GetResourcesByUniversalIdsAsync(ResourceRefs refs);
     }
 
     public interface IPreflightConceptReader
     {
-        Task<PreflightConcepts> GetAsync(ConceptRef @ref);
-        Task<PreflightConcepts> GetAsync(HashSet<ConceptRef> ids);
+        Task<PreflightConcepts> GetConceptsByIdAsync(Guid id);
+        Task<PreflightConcepts> GetConceptsByUniversalIdAsync(Urn uid);
+        Task<PreflightConcepts> GetConceptsByIdsAsync(HashSet<Guid> ids);
+        Task<PreflightConcepts> GetConceptsByUniversalIdsAsync(HashSet<string> uids);
     }
 }

--- a/src/server/Model/Search/PreflightResourceChecker.cs
+++ b/src/server/Model/Search/PreflightResourceChecker.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) 2019, UW Medicine Research IT, University of Washington
+// Developed by Nic Dobbins and Cliff Spital, CRIO Sean Mooney
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Model.Compiler;
+using Model.Authorization;
+using System.Linq;
+
+namespace Model.Search
+{
+    /// <summary>
+    /// Encapsulates Leaf's data constraint and hydration layer. Concepts and resources are only available if the preflight check passed.
+    /// </summary>
+    /// <remarks>
+    /// Required services throw exceptions that bubble up.
+    /// </remarks>
+    public class PreflightResourceChecker
+    {
+        readonly IPreflightResourceReader reader;
+        readonly ILogger<PreflightResourceChecker> log;
+        readonly IUserContext user;
+
+        public PreflightResourceChecker(
+            IPreflightResourceReader reader,
+            IUserContext user,
+            ILogger<PreflightResourceChecker> log)
+        {
+            this.reader = reader;
+            this.user = user;
+            this.log = log;
+        }
+
+        /// <summary>
+        /// Preflight checks a single concept.
+        /// </summary>
+        /// <returns>Preflight check results, which contains the actual concepts if the check passed.</returns>
+        /// <param name="cr">Concept reference.</param>
+        public async Task<PreflightConcepts> GetConceptsAsync(ConceptRef cr)
+        {
+            log.LogInformation("Getting preflight concept check. Ref:{@Ref}", cr);
+            if (user.IsInstutional)
+            {
+                return await reader.GetConceptsByIdAsync(cr.Id.Value);
+            }
+            return await reader.GetConceptsByUniversalIdAsync(cr.UniversalId);
+        }
+
+        /// <summary>
+        /// Preflight checks concepts.
+        /// </summary>
+        /// <returns>Preflight check results, which contains the actual concepts if the check passed.</returns>
+        /// <param name="crs">Concept references.</param>
+        public async Task<PreflightConcepts> GetConceptsAsync(HashSet<ConceptRef> crs)
+        {
+            log.LogInformation("Getting preflight check concepts. Refs:{@Refs}", crs);
+            if (user.IsInstutional)
+            {
+                return await reader.GetConceptsByIdsAsync(crs.Select(c => c.Id.Value).ToHashSet());
+            }
+            return await reader.GetConceptsByUniversalIdsAsync(crs.Select(c => c.UniversalId.ToString()).ToHashSet());
+        }
+
+        /// <summary>
+        /// Preflight checks resources.
+        /// </summary>
+        /// <returns>Preflight check results, which contains the actual resources if the check passed.</returns>
+        /// <param name="refs">Resource references.</param>
+        public async Task<PreflightResources> GetResourcesAsync(ResourceRefs refs)
+        {
+            log.LogInformation("Getting preflight resource check. Refs:{@Refs}", refs);
+            if (user.IsInstutional)
+            {
+                return await reader.GetResourcesByIdsAsync(refs);
+            }
+            return await reader.GetResourcesByUniversalIdsAsync(refs);
+        }
+    }
+}

--- a/src/server/Services/Search/DatasetQueryService.cs
+++ b/src/server/Services/Search/DatasetQueryService.cs
@@ -4,21 +4,23 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 using System;
-using System.Threading.Tasks;
+using System.Collections.Generic;
 using System.Data;
 using System.Data.SqlClient;
 using System.Linq;
+using System.Threading.Tasks;
 using Dapper;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Model.Authorization;
 using Model.Compiler;
 using Model.Options;
-using Services.Authorization;
-using Services.Extensions;
-using Microsoft.Extensions.Options;
-using Microsoft.Extensions.Logging;
-using System.Collections.Generic;
-using Model.Authorization;
-using Services.Tables;
 using Model.Search;
+using Services.Extensions;
+using Services.Tables;
+
+// NOTE(cspital) this service does too much, blow it up and reduce it to the 4 hydrator types as call sites.
+// adding the context should happen at the inevitable model layer for this use case.
 
 namespace Services.Search
 {

--- a/src/server/Services/Search/DemographicQueryService.cs
+++ b/src/server/Services/Search/DemographicQueryService.cs
@@ -17,6 +17,9 @@ using Services.Extensions;
 using Model.Authorization;
 using Model.Search;
 
+// NOTE(cspital) this service does too much, blow it up and reduce it to the 2 hydrator types as call sites.
+// adding the context should happen at the inevitable model layer for this use case.
+
 namespace Services.Search
 {
     using Hydrator = Func<QueryRef, Task<DemographicCompilerContext>>;
@@ -42,6 +45,7 @@ namespace Services.Search
             log = logger;
         }
 
+        // TODO(cspital) move this to admin service
         public async Task<DemographicQuery> GetDemographicQueryAsync()
         {
             log.LogInformation("Getting DemographicQuery");
@@ -157,6 +161,7 @@ namespace Services.Search
             }
         }
 
+        // TODO(cspital) move this to admin service
         public async Task<DemographicQuery> UpdateDemographicQueryAsync(DemographicQuery query)
         {
             log.LogInformation("Updating DemographicQuery SqlStatement:{SqlStatement}", query.SqlStatement);
@@ -180,6 +185,7 @@ namespace Services.Search
             }
         }
 
+        // TODO(cspital) delete this
         void ThrowIfInvalid(DemographicQueryRecord record)
         {
             if (record == null)


### PR DESCRIPTION
IPreflightResourceReader was hiding it's dual id vs uid capability behind it's signatures. this functionality is truly required by the model so lifting it up to be visible was necessary.
Model.Search.PreflightResourceChecker now deals with that user based decision.
PreflightResourceChecker is now the only type directly dependent on IPreflightResourceReader.

DatasetQueryService and DemographicQueryService are also too clever, they're up next. The context state calculation and logging should be lifted up into a to be written model type. `[Dataset|Demographic]ContextValidator([Dataset|Demographic]CompilerContext) --> CompilerValidationContext`.