### PR TITLE
fixed incorrect call in networkcontroller

### DIFF
--- a/src/server/API/Controllers/NetworkController.cs
+++ b/src/server/API/Controllers/NetworkController.cs
@@ -39,7 +39,7 @@ namespace API.Controllers
         {
             try
             {
-                var idEndpoints = await provider.GetEndpointsWithIdentityAsync();
+                var idEndpoints = await provider.GetRespondersWithIdentityAsync();
                 return Ok(new NetworkIdentityRespondersDTO(idEndpoints, runtime.Runtime));
             }
             catch (Exception ex)


### PR DESCRIPTION
corrected canonical call path in networkcontroller.Responders to GetResponders instead of GetEndpoints.
responder only selection left in the respondersdto, type invariant.