### PR TITLE
initial attempt at fixing gateway query saving

### DIFF
--- a/src/server/API/Controllers/CohortController.cs
+++ b/src/server/API/Controllers/CohortController.cs
@@ -33,49 +33,6 @@ namespace API.Controllers
             log = logger;
         }
 
-        [HttpPost("count")]
-        public async Task<ActionResult<CohortCountDTO>> Count(
-            [FromBody] PatientCountQueryDTO patientCountQuery,
-            [FromServices] CohortCounter counter,
-            CancellationToken cancelToken)
-        {
-            try
-            {
-                var cohort = await counter.Count(patientCountQuery, cancelToken);
-                var resp = new CohortCountDTO(cohort);
-                if (!cohort.ValidationContext.PreflightPassed)
-                {
-                    return BadRequest(resp);
-                }
-
-                return Ok(resp);
-            }
-            catch (ArgumentNullException ane)
-            {
-                log.LogError("Missing argument. Error:{Error}", ane.Message);
-                return BadRequest();
-            }
-            catch (OperationCanceledException)
-            {
-                log.LogInformation("Request cancelled.");
-                return NoContent();
-            }
-            catch (LeafCompilerException ce)
-            {
-                log.LogError("Unrecoverable validation error in query. Error:{Error}", ce.Message);
-                return BadRequest();
-            }
-            catch (LeafRPCException le)
-            {
-                return StatusCode(le.StatusCode);
-            }
-            catch (Exception ex)
-            {
-                log.LogError("Failed to execute query. Error:{Error}", ex.ToString());
-                return StatusCode(StatusCodes.Status500InternalServerError);
-            }
-        }
-
         [HttpGet("{queryid}/demographics")]
         public async Task<ActionResult<Demographic>> Demographics(
             string queryid,

--- a/src/server/API/Controllers/CohortCountController.cs
+++ b/src/server/API/Controllers/CohortCountController.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) 2019, UW Medicine Research IT, University of Washington
+// Developed by Nic Dobbins and Cliff Spital, CRIO Sean Mooney
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using API.DTO.Cohort;
+using API.DTO.Compiler;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Model.Authorization;
+using Model.Cohort;
+using Model.Compiler;
+using Model.Error;
+using API.Controllers.Base;
+using Model.Options;
+
+namespace API.Controllers
+{
+    [Authorize(Policy = TokenType.Access)]
+    [Route("api/cohort/count")]
+    public class CohortCountController : Controller
+    {
+        readonly ILogger<CohortCountController> log;
+
+        public CohortCountController(ILogger<CohortCountController> logger)
+        {
+            log = logger;
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<CohortCountDTO>> Count(
+            [FromBody] PatientCountQueryDTO patientCountQuery,
+            [FromServices] CohortCounter counter,
+            CancellationToken cancelToken)
+        {
+            try
+            {
+                var cohort = await counter.Count(patientCountQuery, cancelToken);
+                var resp = new CohortCountDTO(cohort);
+                if (!cohort.ValidationContext.PreflightPassed)
+                {
+                    return BadRequest(resp);
+                }
+
+                return Ok(resp);
+            }
+            catch (ArgumentNullException ane)
+            {
+                log.LogError("Missing argument. Error:{Error}", ane.Message);
+                return BadRequest();
+            }
+            catch (OperationCanceledException)
+            {
+                log.LogInformation("Request cancelled.");
+                return NoContent();
+            }
+            catch (LeafCompilerException ce)
+            {
+                log.LogError("Unrecoverable validation error in query. Error:{Error}", ce.Message);
+                return BadRequest();
+            }
+            catch (LeafRPCException le)
+            {
+                return StatusCode(le.StatusCode);
+            }
+            catch (Exception ex)
+            {
+                log.LogError("Failed to execute query. Error:{Error}", ex.ToString());
+                return StatusCode(StatusCodes.Status500InternalServerError);
+            }
+        }
+    }
+}

--- a/src/server/Model/Cohort/CohortCounter.cs
+++ b/src/server/Model/Cohort/CohortCounter.cs
@@ -9,8 +9,10 @@ using System.Threading.Tasks;
 using Model.Compiler;
 using Model.Authorization;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Model.Validation;
 using Model.Error;
+using Model.Options;
 
 namespace Model.Cohort
 {
@@ -38,20 +40,95 @@ namespace Model.Cohort
         readonly ICohortCacheService cohortCache;
         readonly IUserContext user;
         readonly ILogger<CohortCounter> log;
+        readonly RuntimeMode runtime;
 
-        public CohortCounter(PanelConverter converter,
+        public CohortCounter(
+            IOptions<RuntimeOptions> opts,
+            PanelConverter converter,
             PanelValidator validator,
             IPatientCohortService counter,
             ICohortCacheService cohortCache,
             IUserContext user,
             ILogger<CohortCounter> log)
         {
+            this.runtime = opts.Value.Runtime;
             this.converter = converter;
             this.validator = validator;
             this.counter = counter;
             this.cohortCache = cohortCache;
             this.user = user;
             this.log = log;
+        }
+
+        /// <summary>
+        /// Provide a count of patients in the specified query.
+        /// </summary>
+        /// <returns><see cref="Result">The count of patients in the cohort.</see></returns>
+        /// <param name="queryDTO">Abstract query representation.</param>
+        /// <param name="token">Cancellation token.</param>
+        /// <exception cref="OperationCanceledException"/>
+        /// <exception cref="LeafCompilerException"/>
+        /// <exception cref="ArgumentNullException"/>
+        /// <exception cref="LeafRPCException"/>
+        /// <exception cref="System.Data.Common.DbException"/>
+        public async Task<Result> Count(IPatientCountQueryDTO queryDTO, CancellationToken token)
+        {
+            switch (runtime)
+            {
+                case RuntimeMode.Gateway:
+                    return await GatewayCount(queryDTO, token);
+                default:
+                    return await FullCount(queryDTO, token);
+            }
+        }
+
+        /// <summary>
+        /// Provide an zero count of patients in the specified query.
+        /// Converts the query into a local validation context.
+        /// Validates the resulting context to ensure sensible construction.
+        /// Creates a queryId and empty cohort.
+        /// </summary>
+        /// <returns><see cref="Result">The count of patients in the cohort.</see></returns>
+        /// <param name="queryDTO">Abstract query representation.</param>
+        /// <param name="token">Cancellation token.</param>
+        /// <exception cref="OperationCanceledException"/>
+        /// <exception cref="LeafCompilerException"/>
+        /// <exception cref="ArgumentNullException"/>
+        /// <exception cref="LeafRPCException"/>
+        /// <exception cref="System.Data.Common.DbException"/>
+        async Task<Result> GatewayCount(IPatientCountQueryDTO queryDTO, CancellationToken token)
+        {
+            log.LogInformation("CohortCounter.GatewayCount starting. DTO:{@DTO}", queryDTO);
+            Ensure.NotNull(queryDTO, nameof(queryDTO));
+
+            var ctx = await converter.GetPanelsAsync(queryDTO, token);
+            log.LogInformation("CohortCounter.GatewayCount conversion done. ValidationContext:{@ValidationContext}", ctx);
+
+            if (!ctx.PreflightPassed)
+            {
+                return new Result
+                {
+                    ValidationContext = ctx
+                };
+            }
+
+            validator.Validate(ctx);
+
+            token.ThrowIfCancellationRequested();
+
+            var cohort = new PatientCohort();
+            var qid = await CacheCohort(cohort);
+
+            return new Result
+            {
+                ValidationContext = ctx,
+                Count = new PatientCount
+                {
+                    QueryId = qid,
+                    Value = cohort.Count,
+                    SqlStatements = cohort.SqlStatements
+                }
+            };
         }
 
         /// <summary>
@@ -69,13 +146,13 @@ namespace Model.Cohort
         /// <exception cref="ArgumentNullException"/>
         /// <exception cref="LeafRPCException"/>
         /// <exception cref="System.Data.Common.DbException"/>
-        public async Task<Result> Count(IPatientCountQueryDTO queryDTO, CancellationToken token)
+        async Task<Result> FullCount(IPatientCountQueryDTO queryDTO, CancellationToken token)
         {
-            log.LogInformation("CohortCounter starting. DTO:{@DTO}", queryDTO);
+            log.LogInformation("CohortCounter.FullCount starting. DTO:{@DTO}", queryDTO);
             Ensure.NotNull(queryDTO, nameof(queryDTO));
 
             var ctx = await converter.GetPanelsAsync(queryDTO, token);
-            log.LogInformation("CohortCounter conversion done. ValidationContext:{@ValidationContext}", ctx);
+            log.LogInformation("CohortCounterl.FullCount conversion done. ValidationContext:{@ValidationContext}", ctx);
 
             if (!ctx.PreflightPassed)
             {

--- a/src/server/Model/Cohort/PatientCohort.cs
+++ b/src/server/Model/Cohort/PatientCohort.cs
@@ -12,7 +12,7 @@ namespace Model.Cohort
     public class PatientCohort
     {
         public Guid? QueryId { get; set; }
-        public HashSet<string> PatientIds { get; set; }
+        public HashSet<string> PatientIds { get; set; } = new HashSet<string>();
         public IEnumerable<string> SqlStatements { get; set; }
 
         int count;
@@ -33,6 +33,8 @@ namespace Model.Cohort
                 return count;
             }
         }
+
+        public bool Any() => PatientIds.Any();
 
         public IEnumerable<SeasonedPatient> SeasonedPatients(int maxExport, Guid queryId)
         {

--- a/src/server/Services/Cohort/CohortCacheService.cs
+++ b/src/server/Services/Cohort/CohortCacheService.cs
@@ -57,9 +57,8 @@ namespace Services.Cohort
                     commandTimeout: dbOptions.DefaultTimeout
                 );
 
-                if (cohort.Count <= cohortOptions.RowLimit)
+                if (cohort.Any() && cohort.Count <= cohortOptions.RowLimit)
                 {
-
                     var cohortTable = new PatientCohortTable(queryId, cohort.SeasonedPatients(cohortOptions.ExportLimit, queryId));
 
                     using (var bc = new SqlBulkCopy(cn))
@@ -95,11 +94,11 @@ namespace Services.Cohort
         Guid NonceOrThrowIfNull(IUserContext user)
         {
             var nonce = user?.SessionNonce;
-            if (nonce == null)
+            if (!nonce.HasValue)
             {
-                throw new ArgumentNullException(nameof(user));
+                throw new ArgumentNullException(nameof(nonce));
             }
-            return (Guid)nonce;
+            return nonce.Value;
         }
     }
 }


### PR DESCRIPTION
cohort counter is now aware of the RuntimeMode.
If Gateway, fake an empty cohort and let the cacher "cache" it.
If Full, do the normal cohort fetch and cache activity.