### PR TITLE
Add PUT and DELETE to API CORS methods

### DIFF
--- a/src/server/API/Startup.cs
+++ b/src/server/API/Startup.cs
@@ -69,7 +69,7 @@ namespace API
             {
                 builder.WithOrigins("*");
                 builder.WithHeaders("Accept", "Content-Type", "Origin", "Authorization");
-                builder.WithMethods("POST", "GET", "OPTIONS");
+                builder.WithMethods("POST", "GET", "OPTIONS", "PUT", "DELETE");
             });
 
             app.UseAuthentication();


### PR DESCRIPTION
PUT and DELTE were not in the list of allowed CORS methods.  Although these are potentially modifying/destructive methods, because POST was already listed it seemed plausible that they could be too.

Are there security implications in the original design of Leaf why these were not include initially?