### PR TITLE
Mark dataset date constraint visually

### DIFF
--- a/src/ui-client/src/components/PatientList/AddDatasetButton/AddDatasetButton.tsx
+++ b/src/ui-client/src/components/PatientList/AddDatasetButton/AddDatasetButton.tsx
@@ -37,12 +37,12 @@ const none: DateFilter = { dateIncrementType: DateIncrementType.NONE };
 const today: DateFilter = { dateIncrementType: DateIncrementType.NOW };
 const dates: DateBoundary[] = [
     { display: 'Anytime', start: none, end: none },
-    { display: 'In Past 48 Hours', start: { increment: -48, dateIncrementType: DateIncrementType.HOUR }, end: today },
-    { display: 'In Past 7 Days', start: { increment: -7, dateIncrementType: DateIncrementType.DAY }, end: today },
-    { display: 'In Past 30 Days', start: { increment: -30, dateIncrementType: DateIncrementType.DAY }, end: today },
-    { display: 'In Past 6 Months', start: { increment: -6, dateIncrementType: DateIncrementType.MONTH }, end: today },
-    { display: 'In Past 12 Months', start: { increment: -12, dateIncrementType: DateIncrementType.MONTH }, end: today },
-    { display: 'In Past 2 Years', start: { increment: -2, dateIncrementType: DateIncrementType.YEAR }, end: today },
+    { display: 'In Past 48 Hours', abbrev: '48H', start: { increment: -48, dateIncrementType: DateIncrementType.HOUR }, end: today },
+    { display: 'In Past 7 Days', abbrev: '7D', start: { increment: -7, dateIncrementType: DateIncrementType.DAY }, end: today },
+    { display: 'In Past 30 Days', abbrev: '30D', start: { increment: -30, dateIncrementType: DateIncrementType.DAY }, end: today },
+    { display: 'In Past 6 Months', abbrev: '6M', start: { increment: -6, dateIncrementType: DateIncrementType.MONTH }, end: today },
+    { display: 'In Past 12 Months', abbrev: '12M', start: { increment: -12, dateIncrementType: DateIncrementType.MONTH }, end: today },
+    { display: 'In Past 2 Years', abbrev: '2Y', start: { increment: -2, dateIncrementType: DateIncrementType.YEAR }, end: today },
     { display: 'In Past 3 Years', start: { increment: -3, dateIncrementType: DateIncrementType.YEAR }, end: today }
 ];
 

--- a/src/ui-client/src/components/PatientList/DatasetColumnSelector.tsx
+++ b/src/ui-client/src/components/PatientList/DatasetColumnSelector.tsx
@@ -46,7 +46,10 @@ export default class DatasetColumnSelector extends React.PureComponent<Props, St
             <div className={`${c}-dataset`} onClick={this.handleClick}>
                 {data.displayName}
                 {data.dateBounds && data.dateBounds!.abbrev &&
-                    <abbr title={data.dateBounds!.display} className={`${cs}-nameQualifier`}><span className={`${cs}-nameQualifier-dateBoundsAbbrev`}>{data.dateBounds!.abbrev}</span><GiBackwardTime /></abbr>
+                    <abbr title={data.dateBounds!.display} className={`${cs}-nameQualifier`}>
+                        <span className={`${cs}-nameQualifier-dateBoundsAbbrev`}>{data.dateBounds!.abbrev}</span>
+                        <GiBackwardTime />
+                    </abbr>
                 }
                 {this.state.showColumnBox &&
                     <PopupBox 

--- a/src/ui-client/src/components/PatientList/DatasetColumnSelector.tsx
+++ b/src/ui-client/src/components/PatientList/DatasetColumnSelector.tsx
@@ -46,8 +46,8 @@ export default class DatasetColumnSelector extends React.PureComponent<Props, St
             <div className={`${c}-dataset`} onClick={this.handleClick}>
                 {data.displayName}
                 {data.dateBounds && data.dateBounds!.abbrev &&
-                    <abbr title={data.dateBounds!.display} className={`${cs}-nameQualifier`}>
-                        <span className={`${cs}-nameQualifier-dateBoundsAbbrev`}>{data.dateBounds!.abbrev}</span>
+                    <abbr title={data.dateBounds!.display} className={`${cs}-name-qualifier`}>
+                        <span className={`${cs}-name-qualifier-date-bounds-abbrev`}>{data.dateBounds!.abbrev}</span>
                         <GiBackwardTime />
                     </abbr>
                 }

--- a/src/ui-client/src/components/PatientList/DatasetColumnSelector.tsx
+++ b/src/ui-client/src/components/PatientList/DatasetColumnSelector.tsx
@@ -12,6 +12,7 @@ import CheckBoxSlider from '../Other/CheckboxSlider/CheckboxSlider';
 import PopupBox from '../Other/PopupBox/PopupBox';
 import { PatientListDatasetDefinition, PatientListDatasetSummaryType } from '../../models/patientList/Dataset';
 import { PatientListColumn } from '../../models/patientList/Column';
+import { GiBackwardTime } from "react-icons/gi";
 
 interface Props {
     allowRemove: boolean;
@@ -44,6 +45,9 @@ export default class DatasetColumnSelector extends React.PureComponent<Props, St
         return (
             <div className={`${c}-dataset`} onClick={this.handleClick}>
                 {data.displayName}
+                {data.dateBounds && data.dateBounds!.abbrev &&
+                    <abbr title={data.dateBounds!.display} className={`${cs}-nameQualifier`}><span className={`${cs}-nameQualifier-dateBoundsAbbrev`}>{data.dateBounds!.abbrev}</span><GiBackwardTime /></abbr>
+                }
                 {this.state.showColumnBox &&
                     <PopupBox 
                         parentDomRect={this.state.DOMRect!} 

--- a/src/ui-client/src/containers/PatientList/PatientList.css
+++ b/src/ui-client/src/containers/PatientList/PatientList.css
@@ -139,6 +139,18 @@
     color: rgb(24, 142, 185);
 }
 
+.patientlist-column-selector-nameQualifier {
+    position: relative;
+    width: 50px;
+    margin-left: 2px
+}
+
+.patientlist-column-selector-nameQualifier-dateBoundsAbbrev {
+    position: absolute;
+    top: 10px;
+    font-size: 10px;
+}
+
 .patientlist-dataset-column-selector-container {
     font-family: Roboto;
     min-height: 40px;

--- a/src/ui-client/src/containers/PatientList/PatientList.css
+++ b/src/ui-client/src/containers/PatientList/PatientList.css
@@ -139,13 +139,13 @@
     color: rgb(24, 142, 185);
 }
 
-.patientlist-column-selector-nameQualifier {
+.patientlist-column-selector-name-qualifier {
     position: relative;
     width: 50px;
     margin-left: 2px
 }
 
-.patientlist-column-selector-nameQualifier-dateBoundsAbbrev {
+.patientlist-column-selector-name-qualifier-date-bounds-abbrev {
     position: absolute;
     top: 10px;
     font-size: 10px;

--- a/src/ui-client/src/models/panel/Date.ts
+++ b/src/ui-client/src/models/panel/Date.ts
@@ -7,6 +7,7 @@
 
 export interface DateBoundary {
     display?: string;
+    abbrev?: string;
     start: DateFilter;
     end: DateFilter;
 }


### PR DESCRIPTION
Related to #489, this hopes to make it clearer to the user when they have selected a date range for an encounters-based dataset.

It displays like this:
![image](https://user-images.githubusercontent.com/78827/146318304-31b01a44-d515-4ebb-a0a2-45de93e7190f.png)

Selecting "Anytime" will show as:
![image](https://user-images.githubusercontent.com/78827/146318402-09137159-b86f-4805-8d8a-d95760bde0c9.png)

I do no currently have an icon for "At selected encounters" but obviously that can also be added.