### PR TITLE
fix implicit conversion error

### DIFF
--- a/src/server/Services/Compiler/LeafDbDataReader.cs
+++ b/src/server/Services/Compiler/LeafDbDataReader.cs
@@ -73,11 +73,11 @@ namespace Services.Compiler
         public int GetOrdinal(string colName)           => reader.GetOrdinal(colName);
         public string GetNullableString(int index)      => reader.IsDBNull(index) ? null : reader.GetString(index);
         public Guid GetGuid(int index)                  => reader.GetGuid(index);
-        public Guid? GetNullableGuid(int index)         => reader.IsDBNull(index) ? null : reader.GetGuid(index);
-        public DateTime? GetNullableDateTime(int index) => reader.IsDBNull(index) ? null : reader.GetDateTime(index);
+        public Guid? GetNullableGuid(int index)         => reader.IsDBNull(index) ? (Guid?)null : reader.GetGuid(index);
+        public DateTime? GetNullableDateTime(int index) => reader.IsDBNull(index) ? (DateTime?)null : reader.GetDateTime(index);
         public bool GetBoolean(int index)               => reader.GetBoolean(index);
-        public bool? GetNullableBoolean(int index)      => reader.IsDBNull(index) ? null : reader.GetBoolean(index);
-        public int? GetNullableInt(int index)           => reader.IsDBNull(index) ? null : reader.GetInt32(index);
+        public bool? GetNullableBoolean(int index)      => reader.IsDBNull(index) ? (bool?)null : reader.GetBoolean(index);
+        public int? GetNullableInt(int index)           => reader.IsDBNull(index) ? (int?)null : reader.GetInt32(index);
         public object GetNullableObject(int index)      => reader.IsDBNull(index) ? null : reader.GetValue(index);
 
         public Guid GetCoercibleGuid(int index)
@@ -253,12 +253,12 @@ namespace Services.Compiler
         }
 
         public string GetNullableString(int index)      => row[index] is string @val ? @val : null;
-        public Guid? GetNullableGuid(int index)         => row[index] is Guid @val ? @val : null;
-        public DateTime? GetNullableDateTime(int index) => row[index] is DateTime @val ? @val : null;
+        public Guid? GetNullableGuid(int index)         => row[index] is Guid @val ? @val : (Guid?)null;
+        public DateTime? GetNullableDateTime(int index) => row[index] is DateTime @val ? @val : (DateTime?)null;
         public Guid GetGuid(int index)                  => Guid.Parse(row[index].ToString());
         public bool GetBoolean(int index)               => (bool)row[index];
-        public bool? GetNullableBoolean(int index)      => row[index] is bool @val ? @val : null;
-        public int? GetNullableInt(int index)           => row[index] is int @val ? @val : null;
+        public bool? GetNullableBoolean(int index)      => row[index] is bool @val ? @val : (bool?)null;
+        public int? GetNullableInt(int index)           => row[index] is int @val ? @val : (int?)null;
         public object GetNullableObject(int index)      => row[index] ?? null;
 
         public int GetOrdinal(string colName)


### PR DESCRIPTION
Fix for implicit conversion error CS0173 during dotnet publish.  See below:

Compiler/LeafDbDataReader.cs(76,60): error CS0173: Type of conditional expression cannot be determined because there is no implicit conversion between '<null>' and 'Guid' [/build/Services/Services.csproj]
Compiler/LeafDbDataReader.cs(77,60): error CS0173: Type of conditional expression cannot be determined because there is no implicit conversion between '<null>' and 'DateTime' [/build/Services/Services.csproj]
Compiler/LeafDbDataReader.cs(79,60): error CS0173: Type of conditional expression cannot be determined because there is no implicit conversion between '<null>' and 'bool' [/build/Services/Services.csproj]
Compiler/LeafDbDataReader.cs(80,60): error CS0173: Type of conditional expression cannot be determined because there is no implicit conversion between '<null>' and 'int' [/build/Services/Services.csproj]
Compiler/LeafDbDataReader.cs(256,60): error CS0173: Type of conditional expression cannot be determined because there is no implicit conversion between 'Guid' and '<null>' [/build/Services/Services.csproj]
Compiler/LeafDbDataReader.cs(257,60): error CS0173: Type of conditional expression cannot be determined because there is no implicit conversion between 'DateTime' and '<null>' [/build/Services/Services.csproj]
Compiler/LeafDbDataReader.cs(260,60): error CS0173: Type of conditional expression cannot be determined because there is no implicit conversion between 'bool' and '<null>' [/build/Services/Services.csproj]
Compiler/LeafDbDataReader.cs(261,60): error CS0173: Type of conditional expression cannot be determined because there is no implicit conversion between 'int' and '<null>' [/build/Services/Services.csproj]
The command '/bin/sh -c dotnet publish -c Release -o /app' returned a non-zero code: 1
