### PR TITLE
Upgrade from .net6.0 to .net8.0

### DIFF
--- a/src/server/API/API.csproj
+++ b/src/server/API/API.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <!-- <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch> -->
     <TieredCompilation>true</TieredCompilation>
     <ReleaseVersion>3.1</ReleaseVersion>

--- a/src/server/Dockerfile
+++ b/src/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0
+FROM mcr.microsoft.com/dotnet/sdk:8.0
 
 RUN useradd leaf                \
     && mkdir /home/leaf/        \

--- a/src/server/Model/Model.csproj
+++ b/src/server/Model/Model.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <!-- <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch> -->
     <TieredCompilation>true</TieredCompilation>
-    <ReleaseVersion>6.0</ReleaseVersion>
+    <ReleaseVersion>8.0</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup>
     <LangVersion>latest</LangVersion>

--- a/src/server/Services/Services.csproj
+++ b/src/server/Services/Services.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <!-- <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch> -->
     <TieredCompilation>true</TieredCompilation>
     <ReleaseVersion>3.1</ReleaseVersion>

--- a/src/server/Tests/Tests.csproj
+++ b/src/server/Tests/Tests.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <!-- <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch> -->
     <TieredCompilation>true</TieredCompilation>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
-    <ReleaseVersion>6.0</ReleaseVersion>
+    <ReleaseVersion>8.0</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/server/_.vscode/launch.json
+++ b/src/server/_.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/API/bin/Debug/net6.0/API.dll",
+            "program": "${workspaceFolder}/API/bin/Debug/net8.0/API.dll",
             "args": [],
             "cwd": "${workspaceFolder}",
             "stopAtEntry": false,


### PR DESCRIPTION
.net6.0 is end of life.  .net8.0 is the current LTS release

https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core

If accepted, this should include also include updates to the setup instructions:

* https://leafdocs.rit.uw.edu/installation/installation_steps/2_app_server/